### PR TITLE
New qbit and partial

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,7 @@ python -m toloka2MediaServer -a "Kimetsu no Yaiba: Hashira Geiko-hen"
 Enter the index of the desired torrent: 0
 Default:KimetsunoYaibaHashiraGeikohen. Enter the codename:
 Enter the season number: 5
-Enter the file extension, e.g., ".mkv":
-Default: /esata/Downloads/toloka/tr:. Enter the download directory path.
+Default: /media/HDD/Jellyfin/Anime:. Enter the download directory path.
 Default: Kimetsu no Yaiba: Hashira Geiko-hen (2024). Enter the directory name for the downloaded files:
 Enter the release group name, or it will default to the torrent's author:
 Default: [WEBRip-1080p][UK+JA][Ukr Sub]. Enter additional metadata tags:
@@ -111,15 +110,30 @@ Default: [WEBRip-1080p][UK+JA][Ukr Sub]. Enter additional metadata tags:
 	```bash
 	python -m toloka2MediaServer --add --url https://toloka.to/t675888 --season 02 --index 2 --correction 0 --title "Tsukimichi -Moonlit Fantasy-"
 	```
+* **Додати новий торрент автоматично (partial season)**
+	```bash
+	python -m toloka2MediaServer --add --url https://toloka.to/t675888 --season 02 --index 2 --correction 0 --title "Tsukimichi -Moonlit Fantasy-" --partial
+	```
+	> Використовуйте `--partial` для часткових релізів сезону, коли реліз містить не всі епізоди сезону
+* **Додати новий торрент з кастомним шляхом завантаження**
+	```bash
+	python -m toloka2MediaServer --add --url https://toloka.to/t675888 --season 02 --index 2 --correction 0 --title "Tsukimichi -Moonlit Fantasy-" --path "/custom/download/path"
+	```
+	> Використовуйте `--path` для вказання кастомної директорії завантаження замість значення за замовчуванням
 * **Оновити всі торренти**
 	```bash
 	python -m toloka2MediaServer
 	```
 * **Завантажити нові серії, якщо торрент оновився**
 	```bash
-	python -m toloka2MediaServer -с CODENAME
+	python -m toloka2MediaServer -c CODENAME
 	```
 	> Коднейм береться з файлу titles.ini, про нього буде вказано пізніше
+* **Примусово завантажити торрент (ігноруючи перевірку наявності)**
+	```bash
+	python -m toloka2MediaServer -c CODENAME --force
+	```
+	> Використовуйте `--force` для примусового завантаження незалежно від наявності торренту
 * **Отримати список чисел із рядка**
 	```bash
 	python -m toloka2MediaServer -n "text1 123"
@@ -136,6 +150,8 @@ crontab -e
 > 0 8 * * * cd /path/to/toloka2MediaServer/ && python3 -m toloka2MediaServer
 
 ## Конфиги
+
+> **Примітка:** Файли конфігурації повинні бути розташовані у папці `data/` в корені проекту: `data/app.ini` та `data/titles.ini`
 
 * ### app.ini
 ```ini
@@ -191,6 +207,7 @@ meta = [WEBRip-1080p][UK+JA][Ukr Sub]
 hash = 97e3023362ebb41263f3266ac3a72cc56eda0885
 adjusted_episode_number = -8
 guid = t678205
+is_partial_season = False
 
 [Tsukimichi]
 episode_index = 2
@@ -204,6 +221,7 @@ meta = [WEBRip-1080p][UK][Ukr Sub]
 hash = 8bcb2b32b4885e6c4a03f909486a03f26a4c9a62
 adjusted_episode_number = 0
 guid = t675888
+is_partial_season = False
 ```
 	
 ### Конфігурація епізодів аніме
@@ -213,7 +231,7 @@ guid = t675888
 |------------------------|-----------------------------------------------------|------------------------------------------------|----------------------------------------------------------------------|
 | episode_index         | 2                                                   | 2                                              | Індекс, що вказує номер епізоду(звідки брати номер епізоду)                                      |
 | season_number          | 02                                                  | 02                                             | Номер сезону                                            |
-| ext_name               | .mkv                                                | .mkv                                           | Формат файлу                                                        |
+| ext_name               | .mkv                                                | .mkv                                           | (застаріле) Формат файлу - визначається автоматично з файлу         |
 | torrent_name           | "Arknights: Touin Kiro (2022)"                     | "Tsukimichi -Moonlit Fantasy- (2021)"          | Базове ім'я для генерації назви торрента, тек та файлів             |
 | download_dir           |                                                     | /media/HDD/Jellyfin/Anime                      | Директорія для завантаження медіа (використовується в Transmission) |
 | publish_date            | 2024-05-23                                          | 2024-05-21                                     | Системне значення для визначення оновлень торренту                   |
@@ -222,6 +240,7 @@ guid = t675888
 | hash                   | 97e...0885          | 12      | Системне значення - ID торрент файлу для майбутнього пошуку           |
 | adjusted_episode_number | -8                                             | 0                                              | Коригування номера епізоду сезону для абсолютного або азіатського неймінгу |
 | guid                   | t678205                                           | t675888                                      | Системне значення для ідентифікації конкретного аніме у списку        |
+| is_partial_season      | False                                             | False                                        | Чи є реліз частковим сезоном (не всі епізоди)                        |
 
 </small>
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 transmission_rpc
 qbittorrent-api
 requests
+bencodepy
 git+https://github.com/CakesTwix/toloka2python

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="toloka2MediaServer",
-    version="0.3.6",
+    version="0.3.7",
     description="Addon to facilitate locating and adding TV series/anime torrents from Toloka/Hurtom with standardized naming for Sonarr/Plex/Jellyfin integration.",
     url="https://github.com/CakesTwix/toloka2MediaServer",
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="toloka2MediaServer",
-    version="0.3.2",
+    version="0.3.3",
     description="Addon to facilitate locating and adding TV series/anime torrents from Toloka/Hurtom with standardized naming for Sonarr/Plex/Jellyfin integration.",
     url="https://github.com/CakesTwix/toloka2MediaServer",
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="toloka2MediaServer",
-    version="0.3.7",
+    version="0.3.8",
     description="Addon to facilitate locating and adding TV series/anime torrents from Toloka/Hurtom with standardized naming for Sonarr/Plex/Jellyfin integration.",
     url="https://github.com/CakesTwix/toloka2MediaServer",
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="toloka2MediaServer",
-    version="0.3.1",
+    version="0.3.2",
     description="Addon to facilitate locating and adding TV series/anime torrents from Toloka/Hurtom with standardized naming for Sonarr/Plex/Jellyfin integration.",
     url="https://github.com/CakesTwix/toloka2MediaServer",
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="toloka2MediaServer",
-    version="0.3.0",
+    version="0.3.1",
     description="Addon to facilitate locating and adding TV series/anime torrents from Toloka/Hurtom with standardized naming for Sonarr/Plex/Jellyfin integration.",
     url="https://github.com/CakesTwix/toloka2MediaServer",
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="toloka2MediaServer",
-    version="0.3.3",
+    version="0.3.4",
     description="Addon to facilitate locating and adding TV series/anime torrents from Toloka/Hurtom with standardized naming for Sonarr/Plex/Jellyfin integration.",
     url="https://github.com/CakesTwix/toloka2MediaServer",
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="toloka2MediaServer",
-    version="0.3.4",
+    version="0.3.5",
     description="Addon to facilitate locating and adding TV series/anime torrents from Toloka/Hurtom with standardized naming for Sonarr/Plex/Jellyfin integration.",
     url="https://github.com/CakesTwix/toloka2MediaServer",
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="toloka2MediaServer",
-    version="0.3.5",
+    version="0.3.6",
     description="Addon to facilitate locating and adding TV series/anime torrents from Toloka/Hurtom with standardized naming for Sonarr/Plex/Jellyfin integration.",
     url="https://github.com/CakesTwix/toloka2MediaServer",
     packages=find_packages(),

--- a/toloka2MediaServer/args_parser.py
+++ b/toloka2MediaServer/args_parser.py
@@ -56,5 +56,8 @@ def get_parser():
     add_group.add_argument(
         "-p", "--path", type=str, help="Series path", required=False
     )
+    add_group.add_argument(
+        "--partial", action="store_true", help="Indicate if this is a partial season release", required=False
+    )
 
     return parser

--- a/toloka2MediaServer/args_parser.py
+++ b/toloka2MediaServer/args_parser.py
@@ -59,5 +59,11 @@ def get_parser():
     add_group.add_argument(
         "--partial", action="store_true", help="Indicate if this is a partial season release", required=False
     )
+    add_group.add_argument(
+        "--release_group", type=str, help="Release group (default: torrent author)", required=False
+    )
+    add_group.add_argument(
+        "--meta", type=str, help="Metadata tags (default: from app config)", required=False
+    )
 
     return parser

--- a/toloka2MediaServer/clients/qbittorrent.py
+++ b/toloka2MediaServer/clients/qbittorrent.py
@@ -491,10 +491,14 @@ class QbittorrentClient(BittorrentClient):
         def verify():
             files = self.get_files(torrent_hash)
             # Verify both: new path exists AND old path is gone
-            old_exists = any(old_path in f.name for f in files)
-            new_exists = any(new_path in f.name for f in files)
+            def top_folder(path: str) -> str:
+                sep = "/" if "/" in path else "\\"
+                return path.split(sep)[0] if path else ""
+
+            old_exists = any(top_folder(f.name) == old_path for f in files)
+            new_exists = any(top_folder(f.name) == new_path for f in files)
             return new_exists and not old_exists
-        
+
         return self._retry_operation(operation, verify, f"rename folder '{old_path}'")
     
     def rename_torrent(self, torrent_hash: str, new_torrent_name: str) -> bool:

--- a/toloka2MediaServer/clients/qbittorrent.py
+++ b/toloka2MediaServer/clients/qbittorrent.py
@@ -1,134 +1,432 @@
-import qbittorrentapi
+"""qBittorrent client implementation with clean, maintainable code."""
+
+import hashlib
+import threading
 import time
-import random
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Callable, Dict, List, Optional, Set
+
+import bencodepy
+import qbittorrentapi
 
 from toloka2MediaServer.clients.bittorrent_client import BittorrentClient
 
 
+class TorrentState(Enum):
+    """Known qBittorrent torrent states."""
+    
+    # Active/downloading states
+    DOWNLOADING = 'downloading'
+    UPLOADING = 'uploading'
+    STALLED_DL = 'stalledDL'
+    STALLED_UP = 'stalledUP'
+    FORCED_DL = 'forcedDL'
+    FORCED_UP = 'forcedUP'
+    META_DL = 'metaDL'
+    ALLOCATING = 'allocating'
+    
+    # Queued states
+    QUEUED_DL = 'queuedDL'
+    QUEUED_UP = 'queuedUP'
+    
+    # Paused/stopped states
+    PAUSED_DL = 'pausedDL'
+    PAUSED_UP = 'pausedUP'
+    STOPPED_DL = 'stoppedDL'
+    STOPPED_UP = 'stoppedUP'
+    
+    # Checking states
+    CHECKING_UP = 'checkingUP'
+    CHECKING_DL = 'checkingDL'
+    CHECKING_RESUME = 'checkingResumeData'
+    
+    # Error states
+    ERROR = 'error'
+    MISSING_FILES = 'missingFiles'
+    UNKNOWN = 'unknown'
+    
+    @classmethod
+    def active_states(cls) -> Set[str]:
+        """States indicating torrent is active/running."""
+        return {
+            cls.DOWNLOADING.value, cls.UPLOADING.value,
+            cls.STALLED_DL.value, cls.STALLED_UP.value,
+            cls.FORCED_DL.value, cls.FORCED_UP.value,
+            cls.META_DL.value, cls.ALLOCATING.value,
+            cls.QUEUED_DL.value, cls.QUEUED_UP.value,
+            cls.CHECKING_DL.value, cls.CHECKING_UP.value,
+        }
+    
+    @classmethod
+    def checking_states(cls) -> Set[str]:
+        """States indicating torrent is being checked."""
+        return {
+            cls.CHECKING_UP.value,
+            cls.CHECKING_DL.value,
+            cls.CHECKING_RESUME.value,
+        }
+    
+    @classmethod
+    def error_states(cls) -> Set[str]:
+        """States indicating an error."""
+        return {
+            cls.ERROR.value,
+            cls.MISSING_FILES.value,
+            cls.UNKNOWN.value,
+        }
+    
+    @classmethod
+    def stopped_states(cls) -> Set[str]:
+        """States indicating torrent is stopped."""
+        return {
+            cls.STOPPED_DL.value,
+            cls.STOPPED_UP.value,
+            cls.PAUSED_DL.value,
+            cls.PAUSED_UP.value,
+        }
+
+
+@dataclass
+class RetryConfig:
+    """Configuration for retry behavior."""
+    max_attempts: int = 10
+    initial_delay: float = 1.0
+    max_delay: float = 10.0
+    backoff_factor: float = 1.5
+    verification_delay: float = 3.0
+
+
+@dataclass
+class TimeoutConfig:
+    """Configuration for timeout behavior (synchronous operations)."""
+    operation_timeout: float = 360.0  # Overall timeout for complex operations
+    recheck_start_timeout: float = 100.0  # Max wait for recheck to start
+    recheck_complete_timeout: float = 30.0  # Max wait for recheck to complete (sync)
+    poll_interval: float = 2.0  # Default polling interval
+
+
+@dataclass
+class BackgroundTaskConfig:
+    """Configuration for background task handling."""
+    max_workers: int = 4  # Max concurrent background recheck tasks
+    recheck_timeout: float = 1800.0  # 30 minutes for background recheck
+    progress_stall_timeout: float = 300.0  # 5 min without progress = warning
+    poll_interval: float = 10.0  # Check every 10 seconds in background
+    quick_start_timeout: float = 30.0  # Max wait to confirm recheck started
+
+
+@dataclass
+class ClientConfig:
+    """Configuration extracted from application config."""
+    host: str
+    port: int
+    username: str
+    password: str
+    category: str = ""
+    tag: str = ""
+    retry: RetryConfig = field(default_factory=RetryConfig)
+    timeout: TimeoutConfig = field(default_factory=TimeoutConfig)
+    background: BackgroundTaskConfig = field(default_factory=BackgroundTaskConfig)
+
+
 class QbittorrentClient(BittorrentClient):
+    """Clean qBittorrent client implementation with async support."""
+    
     def __init__(self, config):
-        """Initialize and log in to the qBittorrent client."""
-        try:
-            super().__init__()
-            self.api_client = qbittorrentapi.Client(
-                host=config.app_config[config.application_config.client]["host"],
-                port=config.app_config[config.application_config.client]["port"],
-                username=config.app_config[config.application_config.client][
-                    "username"
-                ],
-                password=config.app_config[config.application_config.client][
-                    "password"
-                ],
-            )
-
-            self.category = config.app_config[config.application_config.client][
-                "category"
-            ]
-            self.tags = config.app_config[config.application_config.client]["tag"]
-
-            self.api_client.auth_log_in()
-            config.logger.info("Connected to qBittorrent client successfully.")
-        except qbittorrentapi.LoginFailed as e:
-            config.logger.critical(
-                "Failed to log in to qBittorrent: Incorrect login details."
-            )
-            raise
-        except qbittorrentapi.APIConnectionError as e:
-            config.logger.critical(
-                "Failed to connect to qBittorrent: Check connection details."
-            )
-            raise
-        except Exception as e:
-            config.logger.critical(f"An unexpected error occurred: {str(e)}")
-            raise
-
-    def add_torrent(self, torrents, category, tags, is_paused, download_dir):
-        """Add a torrent with verification.
+        """Initialize and log in to the qBittorrent client.
         
         Args:
-            torrents: Torrent file content
-            category (str): Category to assign
-            tags (list): Tags to assign
-            is_paused (bool): Whether to add in paused state
-            download_dir (str): Download directory path
+            config: Application configuration object with client settings and logger.
+        """
+        super().__init__()
+        self.logger = config.logger
+        self.retry_config = RetryConfig()
+        self.timeout_config = TimeoutConfig()
+        self.background_config = BackgroundTaskConfig()
+        
+        # Background task management
+        self._executor = ThreadPoolExecutor(
+            max_workers=self.background_config.max_workers,
+            thread_name_prefix="qbit_recheck_"
+        )
+        self._active_tasks: Dict[str, threading.Event] = {}
+        self._tasks_lock = threading.Lock()
+        
+        self._connect(config)
+    
+    def _connect(self, config):
+        """Establish connection to qBittorrent."""
+        client_config = config.app_config[config.application_config.client]
+        
+        try:
+            self.api_client = qbittorrentapi.Client(
+                host=client_config["host"],
+                port=client_config["port"],
+                username=client_config["username"],
+                password=client_config["password"],
+            )
+            
+            self.category = client_config["category"]
+            self.tags = client_config["tag"]
+            
+            self.api_client.auth_log_in()
+            self._log("Connected to qBittorrent client successfully.")
+            
+        except qbittorrentapi.LoginFailed:
+            self._log("Failed to log in to qBittorrent: Incorrect login details.", "critical")
+            raise
+        except qbittorrentapi.APIConnectionError:
+            self._log("Failed to connect to qBittorrent: Check connection details.", "critical")
+            raise
+        except Exception as e:
+            self._log(f"An unexpected error occurred: {str(e)}", "critical")
+            raise
+    
+    # ==================== LOGGING ====================
+    
+    def _log(self, message: str, level: str = "info"):
+        """Safe logging helper."""
+        if self.logger:
+            getattr(self.logger, level)(message)
+    
+    # ==================== CORE HELPERS ====================
+    
+    def _get_torrent(self, torrent_hash: str):
+        """
+        Get a single torrent by hash.
+        
+        Args:
+            torrent_hash: The hash of the torrent to find.
             
         Returns:
-            str: Torrent hash if successful, None if torrent already exists
+            Torrent object if found, None otherwise.
+        """
+        torrents = self.api_client.torrents_info(torrent_hashes=torrent_hash)
+        for torrent in torrents:
+            if torrent.hash == torrent_hash:
+                return torrent
+        return None
+    
+    def _calculate_torrent_hash(self, torrent_file: bytes) -> str:
+        """
+        Calculate info hash from torrent file bytes.
+        
+        Args:
+            torrent_file: Raw bytes of the .torrent file.
+            
+        Returns:
+            SHA1 hash string of the torrent info dict.
+        """
+        decoded = bencodepy.decode(torrent_file)
+        info = decoded[b'info']
+        info_encoded = bencodepy.encode(info)
+        return hashlib.sha1(info_encoded).hexdigest()
+    
+    def _wait_for_state(
+        self,
+        torrent_hash: str,
+        target_states: Set[str],
+        timeout: float = None,
+        poll_interval: float = None,
+    ) -> Optional[str]:
+        """
+        Wait for torrent to reach one of the target states.
+        
+        Args:
+            torrent_hash: Hash of the torrent to monitor.
+            target_states: Set of state strings to wait for.
+            timeout: Maximum time to wait in seconds.
+            poll_interval: Time between state checks.
+            
+        Returns:
+            The state reached, or None on timeout/not found.
+        """
+        timeout = timeout or self.timeout_config.operation_timeout
+        poll_interval = poll_interval or self.timeout_config.poll_interval
+        start = time.time()
+        
+        while time.time() - start < timeout:
+            torrent = self._get_torrent(torrent_hash)
+            if not torrent:
+                return None
+            
+            if torrent.state in target_states:
+                return torrent.state
+            
+            time.sleep(poll_interval)
+        
+        return None
+    
+    def _wait_until_not_state(
+        self,
+        torrent_hash: str,
+        exclude_states: Set[str],
+        timeout: float = None,
+        poll_interval: float = None,
+    ) -> Optional[str]:
+        """
+        Wait until torrent is NOT in any of the specified states.
+        
+        Args:
+            torrent_hash: Hash of the torrent to monitor.
+            exclude_states: Set of states to wait to exit from.
+            timeout: Maximum time to wait in seconds.
+            poll_interval: Time between state checks.
+            
+        Returns:
+            The new state reached, or None on timeout/not found.
+        """
+        timeout = timeout or self.timeout_config.recheck_complete_timeout
+        poll_interval = poll_interval or self.timeout_config.poll_interval
+        start = time.time()
+        
+        while time.time() - start < timeout:
+            torrent = self._get_torrent(torrent_hash)
+            if not torrent:
+                return None
+            
+            if torrent.state not in exclude_states:
+                return torrent.state
+            
+            time.sleep(poll_interval)
+        
+        return None
+    
+    def _retry_operation(
+        self,
+        operation_func,
+        verification_func,
+        operation_name: str,
+    ) -> bool:
+        """
+        Execute operation with retries and verification.
+        
+        Args:
+            operation_func: Function that performs the operation.
+            verification_func: Function that returns True if operation succeeded.
+            operation_name: Name for logging purposes.
+            
+        Returns:
+            True if operation succeeded and verified, False otherwise.
+            
+        Raises:
+            Exception: If operation fails after all retries.
+        """
+        cfg = self.retry_config
+        delay = cfg.initial_delay
+        
+        for attempt in range(cfg.max_attempts):
+            try:
+                operation_func()
+                time.sleep(cfg.verification_delay)
+                
+                if verification_func():
+                    return True
+                
+                if attempt < cfg.max_attempts - 1:
+                    self._log(
+                        f"{operation_name}: verification failed, attempt {attempt + 1}/{cfg.max_attempts}",
+                        "warning"
+                    )
+                    time.sleep(delay)
+                    delay = min(delay * cfg.backoff_factor, cfg.max_delay)
+                    continue
+                
+                return False
+                
+            except Exception as e:
+                if attempt < cfg.max_attempts - 1:
+                    self._log(
+                        f"{operation_name}: attempt {attempt + 1} failed: {e}",
+                        "warning"
+                    )
+                    time.sleep(delay)
+                    delay = min(delay * cfg.backoff_factor, cfg.max_delay)
+                    continue
+                raise Exception(f"Failed to {operation_name} after {cfg.max_attempts} attempts: {str(e)}")
+        
+        return False
+    
+    # ==================== PUBLIC API ====================
+    
+    def add_torrent(
+        self,
+        torrents,
+        category: str,
+        tags: List[str],
+        is_paused: bool,
+        download_dir: str,
+    ) -> Optional[str]:
+        """
+        Add a torrent with verification.
+        
+        Args:
+            torrents: Torrent file content (bytes).
+            category: Category to assign.
+            tags: Tags to assign.
+            is_paused: Whether to add in paused state.
+            download_dir: Download directory path.
+            
+        Returns:
+            Torrent hash if successful, None if torrent already exists.
         """
         try:
-            # Create unique temporary tag
-            temp_tag = f"temp_{int(time.time())}_{random.randint(1000, 9999)}"
+            # Calculate hash from torrent file before adding
+            torrent_hash = self._calculate_torrent_hash(torrents)
             
-            # Combine with user tags
-            combined_tags = tags.copy() if isinstance(tags, list) else [tags] if tags else []
-            combined_tags.append(temp_tag)
+            # Check if torrent already exists
+            if self._get_torrent(torrent_hash):
+                self._log(f"Torrent {torrent_hash[:8]}... already exists")
+                return None
             
-            # Try to add the torrent
-            self.api_client.torrents.add(
-                torrent_files=torrents, 
-                category=category, 
-                tags=combined_tags, 
-                is_paused=is_paused, 
-                download_path=download_dir
+            # Add the torrent
+            self.api_client.torrents_add(
+                torrent_files=torrents,
+                category=category,
+                tags=tags,
+                is_paused=is_paused,
+                download_path=download_dir,
             )
             
-            # Wait a bit before checking
+            # Wait and verify torrent was added
             time.sleep(1)
             
-            # Get torrent with our unique tag
-            torrents = self.get_torrent_info(
-                status_filter=None,
-                category=category,
-                tags=temp_tag,  # Search by unique temp tag
-                sort='added_on',
-                reverse=True
-            )
-            
-            if torrents:
-                torrent_hash = torrents[0].hash
-                # Remove temporary tag
-                try:
-                    # First remove tag from this torrent
-                    self.api_client.torrents_remove_tags(
-                        tags=temp_tag,
-                        torrent_hashes=torrent_hash
-                    )
-                    
-                    # Delete the temporary tag completely
-                    self.api_client.torrents_delete_tags(tags=temp_tag)
-                except:
-                    # If removing temp tag fails, it's not critical
-                    pass
+            if self._get_torrent(torrent_hash):
                 return torrent_hash
-                
-            # If we get here, likely the torrent already exists
+            
+            # Fallback: torrent might already exist (race condition)
             return None
-                
+            
         except qbittorrentapi.exceptions.Conflict409Error:
             # Explicit handling of duplicate torrent
             return None
         except Exception as e:
             raise Exception(f"Failed to add torrent: {str(e)}")
-
+    
     def get_torrent_info(
-        self, status_filter, category, tags, sort, reverse, torrent_hash=None
+        self,
+        status_filter=None,
+        category=None,
+        tags=None,
+        sort=None,
+        reverse=False,
+        torrent_hash=None,
     ):
-        """Retrieve list of torrents.
+        """
+        Retrieve list of torrents with optional filtering.
         
         Args:
-            status_filter (str): Filter torrents by status:
-                'all', 'downloading', 'seeding', 'completed',
-                'paused', 'active', 'inactive', 'resumed', 'errored',
-                'stalled', 'stalled_uploading', 'stalled_downloading',
-                'checking', 'moving', 'stopped', 'running'
-            category (str): Filter by category
-            tags (list): Filter by tags
-            sort (str): Sort by property
-            reverse (bool): Reverse sort order
-            torrent_hash (str): Filter by torrent hash
+            status_filter: Filter torrents by status.
+            category: Filter by category.
+            tags: Filter by tags.
+            sort: Sort by property.
+            reverse: Reverse sort order.
+            torrent_hash: Filter by specific torrent hash.
             
         Returns:
-            TorrentInfoList: List of matching torrents
+            TorrentInfoList: List of matching torrents.
         """
         return self.api_client.torrents_info(
             status_filter=status_filter,
@@ -136,479 +434,647 @@ class QbittorrentClient(BittorrentClient):
             tag=tags,
             sort=sort,
             reverse=reverse,
-            torrent_hashes=torrent_hash
+            torrent_hashes=torrent_hash,
         )
-
-    def get_files(self, torrent_hash):
+    
+    def get_files(self, torrent_hash: str):
+        """Get files for a specific torrent."""
         return self.api_client.torrents_files(torrent_hash)
-
-    def _retry_operation(self, operation_func, verification_func, operation_name, max_retries=3, retry_delay=2, initial_wait=1):
-        """Helper method to handle retry logic for torrent operations.
-        
-        Args:
-            operation_func: Function that performs the operation
-            verification_func: Function that verifies if operation was successful
-            operation_name (str): Name of operation for error messages
-            max_retries (int): Maximum number of retry attempts
-            retry_delay (int): Delay between retries in seconds
-            initial_wait (int): Initial wait time after operation before first verification
-            
-        Returns:
-            bool: True if operation was successful, False otherwise
-            
-        Raises:
-            Exception: If operation fails after all retries
+    
+    def rename_file(self, torrent_hash: str, old_path: str, new_path: str) -> bool:
         """
-        for attempt in range(max_retries):
-            try:
-                operation_func()
-                # Always wait a bit after the operation before checking
-                time.sleep(initial_wait)
-                
-                if verification_func():
-                    return True
-                    
-                if attempt < max_retries - 1:
-                    time.sleep(retry_delay)
-                    continue
-                    
-                return False
-                
-            except Exception as e:
-                if attempt < max_retries - 1:
-                    time.sleep(retry_delay)
-                    continue
-                raise Exception(f"Failed to {operation_name} after {max_retries} attempts: {str(e)}")
-                
-        return False
-
-    def rename_file(self, torrent_hash, old_path, new_path):
-        """Rename a file in a torrent with retries and verification.
+        Rename a file in a torrent with retries and verification.
         
         Args:
-            torrent_hash (str): Hash of the torrent
-            old_path (str): Current file path
-            new_path (str): New file path
+            torrent_hash: Hash of the torrent.
+            old_path: Current file path.
+            new_path: New file path.
             
         Returns:
-            bool: True if rename was successful
+            True if rename was successful.
         """
         def operation():
             self.api_client.torrents_rename_file(
                 torrent_hash=torrent_hash,
                 old_path=old_path,
-                new_path=new_path
+                new_path=new_path,
             )
-            
+        
         def verify():
             files = self.get_files(torrent_hash)
-            # Check both that new path exists and old path doesn't
-            new_path_exists = any(file.name == new_path for file in files)
-            old_path_exists = any(file.name == old_path for file in files)
-            return new_path_exists and not old_path_exists
-            
-        return self._retry_operation(
-            operation,
-            verify,
-            "rename file",
-            max_retries=10,
-            retry_delay=3,
-            initial_wait=3
-        )
-
-    def rename_folder(self, torrent_hash, old_path, new_path):
-        """Rename a folder in a torrent with retries and verification.
+            # Verify both: new path exists AND old path is gone
+            new_exists = any(f.name == new_path for f in files)
+            old_exists = any(f.name == old_path for f in files)
+            return new_exists and not old_exists
+        
+        return self._retry_operation(operation, verify, f"rename file '{old_path}'")
+    
+    def rename_folder(self, torrent_hash: str, old_path: str, new_path: str) -> bool:
+        """
+        Rename a folder in a torrent with retries and verification.
         
         Args:
-            torrent_hash (str): Hash of the torrent
-            old_path (str): Current folder path
-            new_path (str): New folder path
+            torrent_hash: Hash of the torrent.
+            old_path: Current folder path.
+            new_path: New folder path.
             
         Returns:
-            bool: True if rename was successful
+            True if rename was successful.
         """
         def operation():
             self.api_client.torrents_rename_folder(
                 torrent_hash=torrent_hash,
                 old_path=old_path,
-                new_path=new_path
+                new_path=new_path,
             )
-            
+        
         def verify():
             files = self.get_files(torrent_hash)
-            # Check that no files contain the old path and at least one contains the new path
-            old_path_exists = any(old_path in file.name for file in files)
-            new_path_exists = any(new_path in file.name for file in files)
-            return new_path_exists and not old_path_exists
-            
-        return self._retry_operation(
-            operation,
-            verify,
-            "rename folder",
-            max_retries=10,
-            retry_delay=3,
-            initial_wait=3
-        )
-
-    def rename_torrent(self, torrent_hash, new_torrent_name):
-        """Rename a torrent with retries and verification.
+            # Verify both: new path exists AND old path is gone
+            old_exists = any(old_path in f.name for f in files)
+            new_exists = any(new_path in f.name for f in files)
+            return new_exists and not old_exists
+        
+        return self._retry_operation(operation, verify, f"rename folder '{old_path}'")
+    
+    def rename_torrent(self, torrent_hash: str, new_torrent_name: str) -> bool:
+        """
+        Rename a torrent with retries and verification.
         
         Args:
-            torrent_hash (str): Hash of the torrent
-            new_torrent_name (str): New name for the torrent
+            torrent_hash: Hash of the torrent.
+            new_torrent_name: New name for the torrent.
             
         Returns:
-            bool: True if rename was successful
-            
-        Raises:
-            NotFound404Error: If torrent not found
+            True if rename was successful.
         """
         def operation():
             self.api_client.torrents_rename(
                 torrent_hash=torrent_hash,
-                new_torrent_name=new_torrent_name
+                new_torrent_name=new_torrent_name,
             )
-            
+        
         def verify():
-            torrent_info = self.get_torrent_info(
-                status_filter=None,
-                category=None,
-                tags=None,
-                sort=None,
-                reverse=False,
-                torrent_hash=torrent_hash
-            )
-            return torrent_info and len(torrent_info) > 0 and torrent_info[0].name == new_torrent_name
-            
-        return self._retry_operation(
-            operation,
-            verify,
-            "rename torrent",
-            max_retries=10,
-            retry_delay=3,
-            initial_wait=3
-        )
-
-    def resume_torrent(self, torrent_hashes):
-        """Resume torrent with verification.
+            torrent = self._get_torrent(torrent_hash)
+            return torrent is not None and torrent.name == new_torrent_name
+        
+        return self._retry_operation(operation, verify, f"rename torrent to '{new_torrent_name}'")
+    
+    def resume_torrent(self, torrent_hashes: str) -> bool:
+        """
+        Resume torrent with verification.
         
         Args:
-            torrent_hashes (str): Hash of the torrent
+            torrent_hashes: Hash of the torrent.
             
         Returns:
-            bool: True if resume was successful
+            True if resume was successful.
         """
         def operation():
             self.api_client.torrents_resume(torrent_hashes=torrent_hashes)
-            
+        
         def verify():
-            torrent_info = self.get_torrent_info(
-                status_filter=None,
-                category=None,
-                tags=None,
-                sort=None,
-                reverse=False,
-                torrent_hash=torrent_hashes
-            )
-            if not torrent_info:
+            torrent = self._get_torrent(torrent_hashes)
+            if not torrent:
                 return False
-                
-            state = torrent_info[0].state
-            # States indicating torrent is active or queued
-            valid_states = [
-                'downloading', 'uploading',
-                'stalledDL', 'stalledUP',
-                'forcedDL', 'forcedUP',
-                'metaDL', 'allocating',
-                'checkingDL', 'checkingUP',
-                'queuedDL', 'queuedUP'  # Include queued states as valid
-            ]
-            return state in valid_states
-            
-        return self._retry_operation(
-            operation,
-            verify,
-            "resume torrent",
-            max_retries=10,
-            retry_delay=5,
-            initial_wait=3
-        )
-
-    def delete_torrent(self, delete_files, torrent_hashes):
-        """Delete torrent with verification.
+            return torrent.state in TorrentState.active_states()
+        
+        return self._retry_operation(operation, verify, "resume torrent")
+    
+    def delete_torrent(self, delete_files: bool, torrent_hashes: str) -> bool:
+        """
+        Delete torrent with verification.
         
         Args:
-            delete_files (bool): Whether to delete files along with torrent
-            torrent_hashes (str): Hash of the torrent to delete
+            delete_files: Whether to delete files along with torrent.
+            torrent_hashes: Hash of the torrent to delete.
             
         Returns:
-            bool: True if torrent no longer exists (success), False otherwise
+            True if torrent no longer exists (success).
         """
         try:
-            # First check if torrent exists before trying to delete
-            initial_check = self.get_torrent_info(
-                status_filter=None,
-                category=None,
-                tags=None,
-                sort=None,
-                reverse=False,
-                torrent_hash=torrent_hashes
-            )
-            
-            # Check if the specific torrent hash exists in the results
-            target_exists = any(t.hash == torrent_hashes for t in initial_check)
-            
-            # If torrent doesn't exist, consider it already deleted - return success
-            if not target_exists:
+            # Check if torrent already doesn't exist
+            if not self._get_torrent(torrent_hashes):
                 return True
-                
-            # Torrent exists, try to delete it
+            
+            # Delete the torrent
             self.api_client.torrents_delete(
                 delete_files=delete_files,
-                torrent_hashes=torrent_hashes
+                torrent_hashes=torrent_hashes,
             )
             
-            # Wait a bit before checking
+            # Wait and verify deletion
             time.sleep(1)
             
-            # Verify torrent no longer exists
-            torrent_info = self.get_torrent_info(
-                status_filter=None,
-                category=None,
-                tags=None,
-                sort=None,
-                reverse=False,
-                torrent_hash=torrent_hashes
-            )
+            return self._get_torrent(torrent_hashes) is None
             
-            # Check if the specific torrent hash still exists
-            return not any(t.hash == torrent_hashes for t in torrent_info)
-                
         except Exception as e:
             raise Exception(f"Failed to delete torrent: {str(e)}")
-
-    def recheck_torrent(self, torrent_hashes):
+    
+    def recheck_torrent(self, torrent_hashes: str):
+        """Start recheck on a torrent (no waiting)."""
         return self.api_client.torrents_recheck(torrent_hashes=torrent_hashes)
-
-    def end_session(self):
-        return self.api_client.auth_log_out()
-
-    def recheck_and_resume(self, torrent_hash):
-        """Recheck and resume torrent with verification.
+    
+    # ==================== SYNCHRONOUS RECHECK (Original) ====================
+    
+    def recheck_and_resume(self, torrent_hash: str) -> tuple:
+        """
+        Recheck torrent integrity and resume (synchronous, short timeout).
+        
+        For web UI usage, consider using recheck_and_resume_async() instead,
+        which returns quickly and handles completion in background.
         
         Args:
-            torrent_hash (str): Hash of the torrent
+            torrent_hash: Hash of the torrent.
             
         Returns:
-            bool: True if operation was successful
+            Tuple of (success: bool, message: str or None).
         """
+        overall_start = time.time()
+        timeout = self.timeout_config.operation_timeout
+        
+        def check_timeout():
+            if time.time() - overall_start > timeout:
+                raise TimeoutError(f"Operation timed out after {timeout} seconds")
+        
         try:
-            # Add overall timeout
-            overall_start_time = time.time()
-            overall_timeout = 360
+            # Step 1: Verify torrent exists
+            torrent = self._get_torrent(torrent_hash)
+            if not torrent:
+                return (False, "Torrent not found")
             
-            def check_overall_timeout():
-                if time.time() - overall_start_time > overall_timeout:
-                    raise TimeoutError("Operation timed out after 5 minutes")
-
-            # First verify torrent exists
-            initial_check = self.get_torrent_info(
-                status_filter=None,
-                category=None,
-                tags=None,
-                sort=None,
-                reverse=False,
-                torrent_hash=torrent_hash
-            )
-            
-            if not any(t.hash == torrent_hash for t in initial_check):
-                return (False, None)
-                
-            # Start recheck
+            # Step 2: Start recheck
             try:
                 self.api_client.torrents_recheck(torrent_hashes=torrent_hash)
             except Exception as e:
-                # If recheck fails but torrent exists, continue to resume
-                pass
+                self._log(f"Recheck command failed: {e}", "warning")
             
-            # Wait for recheck to start (with retry)
-            check_interval = 10
-            max_retries = 10
-            recheck_started = False
+            # Step 3: Wait for recheck to start
+            recheck_started = self._wait_for_recheck_start_sync(torrent_hash, check_timeout)
             
-            for _ in range(max_retries):
-                check_overall_timeout()
-                torrent_info = self.get_torrent_info(
-                    status_filter=None,
-                    category=None,
-                    tags=None,
-                    sort=None,
-                    reverse=False,
-                    torrent_hash=torrent_hash
-                )
-                
-                matching_torrents = [t for t in torrent_info if t.hash == torrent_hash]
-                if not matching_torrents:
-                    return (False, None)
-                    
-                state = matching_torrents[0].state
-                if state in ['checkingResumeData', 'checking', 'checkingDL', 'checkingUP']:
-                    recheck_started = True
-                    break
-                elif state == 'stoppedDL':
-                    # If torrent is still stopped, try recheck again
-                    try:
-                        self.api_client.torrents_recheck(torrent_hashes=torrent_hash)
-                    except Exception:
-                        pass
-                    
-                time.sleep(check_interval)
-            
-            # If recheck didn't start, still try to resume
+            # Step 4: Wait for recheck to complete (if it started)
             if recheck_started:
-                # Wait for check to complete with timeout
-                check_timeout = 30
-                start_time = time.time()
-                
-                while time.time() - start_time < check_timeout:
-                    check_overall_timeout()
-                    torrent_info = self.get_torrent_info(
-                        status_filter=None,
-                        category=None,
-                        tags=None,
-                        sort=None,
-                        reverse=False,
-                        torrent_hash=torrent_hash
-                    )
-                    
-                    matching_torrents = [t for t in torrent_info if t.hash == torrent_hash]
-                    if not matching_torrents:
-                        return (False, None)
-                        
-                    state = matching_torrents[0].state
-                    # If no longer checking, break
-                    if state not in ['checkingResumeData', 'checking', 'checkingDL', 'checkingUP']:
-                        break
-                        
-                    time.sleep(2)
+                self._wait_until_not_state(
+                    torrent_hash,
+                    TorrentState.checking_states(),
+                    timeout=self.timeout_config.recheck_complete_timeout,
+                )
             
-            # Resume the torrent
+            check_timeout()
+            
+            # Step 5: Resume the torrent
             try:
                 self.api_client.torrents_resume(torrent_hashes=torrent_hash)
             except Exception as e:
-                # If resume fails but torrent is active, consider it successful
-                pass
+                self._log(f"Resume command failed: {e}", "warning")
             
-            # Wait a bit before final check
             time.sleep(3)
-            check_overall_timeout()
+            check_timeout()
             
-            # Verify torrent is active
-            torrent_info = self.get_torrent_info(
-                status_filter=None,
-                category=None,
-                tags=None,
-                sort=None,
-                reverse=False,
-                torrent_hash=torrent_hash
-            )
+            # Step 6: Verify torrent is active
+            return self._verify_torrent_active_sync(torrent_hash, check_timeout)
             
-            matching_torrents = [t for t in torrent_info if t.hash == torrent_hash]
-            if not matching_torrents:
-                return (False, None)
-                
-            state = matching_torrents[0].state
-            # States indicating torrent is active or queued
-            valid_states = [
-                'downloading', 'uploading',
-                'stalledDL', 'stalledUP',
-                'forcedDL', 'forcedUP',
-                'metaDL', 'allocating',
-                'queuedDL', 'queuedUP',
-                'checkingDL', 'checkingUP'  # Also consider checking states as valid
-            ]
-            
-            if state in valid_states:
-                return (True, f"Torrent active in state: {state}")
-            elif state == 'stoppedDL':
-                # If torrent is still stopped, try to start it anyway
-                try:
-                    self.api_client.torrents_resume(torrent_hashes=torrent_hash)
-                    time.sleep(2)  # Wait a bit for the start command to take effect
-                    
-                    # Check if it started
-                    final_check = self.get_torrent_info(
-                        status_filter=None,
-                        category=None,
-                        tags=None,
-                        sort=None,
-                        reverse=False,
-                        torrent_hash=torrent_hash
-                    )
-                    matching = [t for t in final_check if t.hash == torrent_hash]
-                    if matching and matching[0].state in valid_states:
-                        # Successfully started but recheck failed
-                        return (True, f"Recheck failed for torrent {torrent_hash}, but successfully started it")
-                except Exception:
-                    pass
-                    
-            # After final resume attempt, do multiple checks with increasing delays
-            check_attempts = 3
-            for attempt in range(check_attempts):
-                time.sleep(2 * (attempt + 1))  # Increasing delay: 2s, 4s, 6s
-                
-                final_check = self.get_torrent_info(
-                    status_filter=None,
-                    category=None,
-                    tags=None,
-                    sort=None,
-                    reverse=False,
-                    torrent_hash=torrent_hash
-                )
-                
-                matching = [t for t in final_check if t.hash == torrent_hash]
-                if matching:
-                    current_state = matching[0].state
-                    if current_state in valid_states:
-                        return (True, f"Torrent active in state: {current_state}")
-                    elif attempt < check_attempts - 1:
-                        # Try to resume again if not in last attempt
-                        try:
-                            self.api_client.torrents_resume(torrent_hashes=torrent_hash)
-                        except:
-                            pass
-
-            # Final fallback check - if torrent exists and isn't in an error state, consider it successful
-            final_check = self.get_torrent_info(
-                status_filter=None,
-                category=None,
-                tags=None,
-                sort=None,
-                reverse=False,
-                torrent_hash=torrent_hash
-            )
-            matching = [t for t in final_check if t.hash == torrent_hash]
-            if matching and matching[0].state not in ['error', 'missingFiles', 'unknown']:
-                return (True, f"Torrent exists in state: {matching[0].state}")
-
-            return (False, f"Torrent in invalid state: {matching[0].state if matching else 'not found'}")
-                
         except TimeoutError as e:
             raise Exception(f"Operation timed out: {str(e)}")
         except Exception as e:
-            # Log error but return True if we can verify torrent is active
-            try:
-                torrent_info = self.get_torrent_info(
-                    status_filter=None,
-                    category=None,
-                    tags=None,
-                    sort=None,
-                    reverse=False,
-                    torrent_hash=torrent_hash
+            return self._fallback_verification(torrent_hash, e)
+    
+    def _wait_for_recheck_start_sync(self, torrent_hash: str, check_timeout) -> bool:
+        """Wait for recheck to start (synchronous version)."""
+        poll_interval = 10
+        max_attempts = 10
+        
+        for attempt in range(max_attempts):
+            check_timeout()
+            
+            torrent = self._get_torrent(torrent_hash)
+            if not torrent:
+                return False
+            
+            state = torrent.state
+            
+            if state in TorrentState.checking_states():
+                return True
+            
+            if state in TorrentState.stopped_states():
+                try:
+                    self.api_client.torrents_recheck(torrent_hashes=torrent_hash)
+                except Exception:
+                    pass
+            
+            time.sleep(poll_interval)
+        
+        return False
+    
+    def _verify_torrent_active_sync(self, torrent_hash: str, check_timeout) -> tuple:
+        """Verify torrent is active (synchronous version)."""
+        torrent = self._get_torrent(torrent_hash)
+        if not torrent:
+            return (False, "Torrent not found after resume")
+        
+        state = torrent.state
+        
+        if state in TorrentState.active_states():
+            return (True, f"Torrent active in state: {state}")
+        
+        if state in TorrentState.stopped_states():
+            result = self._handle_stopped_state(torrent_hash)
+            if result[0]:
+                return result
+        
+        for attempt in range(3):
+            time.sleep(2 * (attempt + 1))
+            
+            torrent = self._get_torrent(torrent_hash)
+            if not torrent:
+                continue
+            
+            state = torrent.state
+            if state in TorrentState.active_states():
+                return (True, f"Torrent active in state: {state}")
+            
+            if attempt < 2:
+                try:
+                    self.api_client.torrents_resume(torrent_hashes=torrent_hash)
+                except Exception:
+                    pass
+        
+        torrent = self._get_torrent(torrent_hash)
+        if torrent and torrent.state not in TorrentState.error_states():
+            return (True, f"Torrent exists in state: {torrent.state}")
+        
+        final_state = torrent.state if torrent else "not found"
+        return (False, f"Torrent in invalid state: {final_state}")
+    
+    def _handle_stopped_state(self, torrent_hash: str) -> tuple:
+        """Handle torrent stuck in stopped state."""
+        try:
+            self.api_client.torrents_resume(torrent_hashes=torrent_hash)
+            time.sleep(2)
+            
+            torrent = self._get_torrent(torrent_hash)
+            if torrent and torrent.state in TorrentState.active_states():
+                return (True, f"Torrent started after stopped state: {torrent.state}")
+        except Exception:
+            pass
+        
+        return (False, None)
+    
+    def _fallback_verification(self, torrent_hash: str, original_error: Exception) -> tuple:
+        """Final fallback verification after an error."""
+        try:
+            torrent = self._get_torrent(torrent_hash)
+            if torrent and torrent.state not in TorrentState.error_states():
+                return (True, f"Torrent exists despite error: {torrent.state}")
+        except Exception:
+            pass
+        
+        raise Exception(f"Failed to recheck and resume torrent: {str(original_error)}")
+    
+    # ==================== ASYNC RECHECK (Background Worker) ====================
+    
+    def recheck_and_resume_async(
+        self,
+        torrent_hash: str,
+        on_complete: Optional[Callable[[bool, str], None]] = None,
+    ) -> tuple:
+        """
+        Start recheck and return immediately once recheck begins.
+        Completion is handled in a background thread.
+        
+        This is the recommended method for web UI usage where you don't
+        want to block the request for potentially 30+ minutes.
+        
+        Args:
+            torrent_hash: Hash of the torrent.
+            on_complete: Optional callback(success, message) when background completes.
+            
+        Returns:
+            (True, "message") if recheck started successfully and is being monitored.
+            (False, "message") if failed to start recheck.
+        """
+        # Step 1: Verify torrent exists
+        torrent = self._get_torrent(torrent_hash)
+        if not torrent:
+            return (False, "Torrent not found")
+        
+        # Step 2: Check if already being processed
+        with self._tasks_lock:
+            if torrent_hash in self._active_tasks:
+                return (True, "Recheck already in progress (monitored)")
+        
+        # Step 3: Start recheck
+        try:
+            self.api_client.torrents_recheck(torrent_hashes=torrent_hash)
+        except Exception as e:
+            return (False, f"Failed to start recheck: {e}")
+        
+        # Step 4: Wait briefly for recheck to actually start
+        recheck_started = self._quick_wait_for_recheck_start(torrent_hash)
+        
+        if not recheck_started:
+            # Check current state - maybe already complete or error
+            torrent = self._get_torrent(torrent_hash)
+            if torrent and torrent.state in TorrentState.active_states():
+                return (True, f"Torrent already active: {torrent.state}")
+            elif torrent and torrent.state in TorrentState.error_states():
+                return (False, f"Torrent in error state: {torrent.state}")
+        
+        # Step 5: Spawn background thread for completion
+        cancel_event = threading.Event()
+        with self._tasks_lock:
+            self._active_tasks[torrent_hash] = cancel_event
+        
+        self._executor.submit(
+            self._background_recheck_completion,
+            torrent_hash,
+            cancel_event,
+            on_complete,
+        )
+        
+        state = "checking" if recheck_started else "pending"
+        return (True, f"Recheck {state}, monitoring in background")
+    
+    def _quick_wait_for_recheck_start(self, torrent_hash: str) -> bool:
+        """
+        Quick check if recheck started within a short timeout.
+        Used by async method to confirm recheck is running before returning.
+        """
+        timeout = self.background_config.quick_start_timeout
+        start = time.time()
+        
+        while time.time() - start < timeout:
+            torrent = self._get_torrent(torrent_hash)
+            if not torrent:
+                return False
+            
+            if torrent.state in TorrentState.checking_states():
+                return True
+            
+            # If already past checking (very fast recheck), also OK
+            if torrent.state in TorrentState.active_states():
+                return True
+            
+            time.sleep(2)
+        
+        return False
+    
+    def _background_recheck_completion(
+        self,
+        torrent_hash: str,
+        cancel_event: threading.Event,
+        on_complete: Optional[Callable[[bool, str], None]],
+    ):
+        """
+        Background thread that waits for recheck completion and resumes.
+        Runs until recheck is complete (could be 30+ minutes).
+        """
+        short_hash = torrent_hash[:8]
+        
+        try:
+            self._log(f"[BG:{short_hash}] Starting recheck monitor...")
+            
+            # Wait for recheck to complete with progress monitoring
+            completed, final_state = self._wait_for_recheck_complete_with_progress(
+                torrent_hash,
+                cancel_event,
+            )
+            
+            if cancel_event.is_set():
+                self._log(f"[BG:{short_hash}] Cancelled")
+                self._notify_complete(on_complete, False, "Cancelled")
+                return
+            
+            if not completed:
+                self._log(f"[BG:{short_hash}] Recheck failed: {final_state}", "error")
+                self._notify_complete(on_complete, False, f"Recheck failed: {final_state}")
+                return
+            
+            self._log(f"[BG:{short_hash}] Recheck complete, resuming...")
+            
+            # Resume the torrent
+            success, message = self._background_resume_and_verify(torrent_hash)
+            
+            if success:
+                self._log(f"[BG:{short_hash}] Success: {message}")
+            else:
+                self._log(f"[BG:{short_hash}] Failed: {message}", "error")
+            
+            self._notify_complete(on_complete, success, message)
+            
+        except Exception as e:
+            self._log(f"[BG:{short_hash}] Error: {e}", "error")
+            self._notify_complete(on_complete, False, f"Background error: {e}")
+        finally:
+            # Cleanup
+            with self._tasks_lock:
+                self._active_tasks.pop(torrent_hash, None)
+    
+    def _wait_for_recheck_complete_with_progress(
+        self,
+        torrent_hash: str,
+        cancel_event: threading.Event,
+    ) -> tuple:
+        """
+        Wait for recheck to complete, monitoring progress for stalls.
+        
+        Returns:
+            (completed: bool, state_or_reason: str)
+        """
+        cfg = self.background_config
+        short_hash = torrent_hash[:8]
+        start = time.time()
+        last_progress = 0.0
+        last_progress_time = start
+        last_logged_progress = -1  # Track last logged percentage
+        
+        while time.time() - start < cfg.recheck_timeout:
+            if cancel_event.is_set():
+                return (False, "cancelled")
+            
+            torrent = self._get_torrent(torrent_hash)
+            if not torrent:
+                return (False, "torrent_not_found")
+            
+            state = torrent.state
+            progress = getattr(torrent, 'progress', 0.0)
+            progress_pct = int(progress * 100)
+            
+            # Recheck complete - not in checking state anymore
+            if state not in TorrentState.checking_states():
+                if state in TorrentState.error_states():
+                    return (False, f"error_state:{state}")
+                self._log(f"[BG:{short_hash}] Recheck finished at 100%")
+                return (True, state)
+            
+            # Log progress every 10%
+            if progress_pct >= last_logged_progress + 10:
+                self._log(f"[BG:{short_hash}] Recheck progress: {progress_pct}%")
+                last_logged_progress = progress_pct
+            
+            # Monitor progress for stalls
+            if progress > last_progress + 0.001:  # More than 0.1% progress
+                last_progress = progress
+                last_progress_time = time.time()
+            elif time.time() - last_progress_time > cfg.progress_stall_timeout:
+                # No progress for too long - log warning but continue
+                # qBit might be busy with other rechecks
+                self._log(
+                    f"[BG:{short_hash}] Recheck stalled at {progress_pct}% for {cfg.progress_stall_timeout}s",
+                    "warning"
                 )
-                matching_torrents = [t for t in torrent_info if t.hash == torrent_hash]
-                if matching_torrents and matching_torrents[0].state not in ['error', 'missingFiles', 'unknown']:
-                    return (True, f"Torrent exists despite error: {matching_torrents[0].state}")
-            except:
-                pass
-            raise Exception(f"Failed to recheck and resume torrent: {str(e)}")
+                # Reset stall timer to avoid spam
+                last_progress_time = time.time()
+            
+            time.sleep(cfg.poll_interval)
+        
+        # Timeout
+        torrent = self._get_torrent(torrent_hash)
+        if torrent and torrent.state in TorrentState.checking_states():
+            progress_pct = int(getattr(torrent, 'progress', 0.0) * 100)
+            return (False, f"timeout_at_{progress_pct}%")
+        
+        # Finished during final check
+        return (True, torrent.state if torrent else "completed")
+    
+    def _background_resume_and_verify(self, torrent_hash: str) -> tuple:
+        """Resume torrent and verify it's active (background version)."""
+        max_attempts = 5
+        short_hash = torrent_hash[:8]
+        
+        for attempt in range(max_attempts):
+            try:
+                self.api_client.torrents_resume(torrent_hashes=torrent_hash)
+            except Exception as e:
+                self._log(f"[BG:{short_hash}] Resume attempt {attempt + 1} failed: {e}", "warning")
+            
+            time.sleep(3)
+            
+            torrent = self._get_torrent(torrent_hash)
+            if not torrent:
+                return (False, "Torrent not found after resume")
+            
+            if torrent.state in TorrentState.active_states():
+                return (True, f"Active in state: {torrent.state}")
+            
+            if torrent.state in TorrentState.error_states():
+                return (False, f"Error state: {torrent.state}")
+            
+            time.sleep(2 * (attempt + 1))  # Backoff
+        
+        # Final check - accept non-error states
+        torrent = self._get_torrent(torrent_hash)
+        if torrent and torrent.state not in TorrentState.error_states():
+            return (True, f"Exists in state: {torrent.state}")
+        
+        return (False, f"Failed to resume after {max_attempts} attempts")
+    
+    def _notify_complete(
+        self,
+        callback: Optional[Callable[[bool, str], None]],
+        success: bool,
+        message: str,
+    ):
+        """Safely invoke completion callback."""
+        if callback:
+            try:
+                callback(success, message)
+            except Exception as e:
+                self._log(f"[BG] Callback error: {e}", "error")
+    
+    # ==================== BACKGROUND TASK MANAGEMENT ====================
+    
+    def cancel_background_recheck(self, torrent_hash: str) -> bool:
+        """
+        Cancel a running background recheck task.
+        
+        Args:
+            torrent_hash: Hash of the torrent to cancel.
+            
+        Returns:
+            True if task was found and cancelled, False if not found.
+        """
+        with self._tasks_lock:
+            if torrent_hash in self._active_tasks:
+                self._active_tasks[torrent_hash].set()
+                return True
+        return False
+    
+    def get_active_background_rechecks(self) -> List[str]:
+        """
+        Get list of torrent hashes with active background rechecks.
+        
+        Returns:
+            List of torrent hashes being monitored.
+        """
+        with self._tasks_lock:
+            return list(self._active_tasks.keys())
+    
+    def is_background_recheck_active(self, torrent_hash: str) -> bool:
+        """
+        Check if a background recheck is active for a torrent.
+        
+        Args:
+            torrent_hash: Hash of the torrent to check.
+            
+        Returns:
+            True if background recheck is active.
+        """
+        with self._tasks_lock:
+            return torrent_hash in self._active_tasks
+    
+    def get_recheck_status(self, torrent_hash: str) -> tuple:
+        """
+        Get current recheck status for a torrent.
+        
+        Args:
+            torrent_hash: Hash of the torrent.
+            
+        Returns:
+            Tuple of (status: str, progress: float).
+            Status is one of: 'not_found', 'checking', 'active', 'error', 'stopped', or state name.
+        """
+        torrent = self._get_torrent(torrent_hash)
+        if not torrent:
+            return ("not_found", 0.0)
+        
+        state = torrent.state
+        progress = getattr(torrent, 'progress', 0.0)
+        
+        if state in TorrentState.checking_states():
+            return ("checking", progress)
+        elif state in TorrentState.active_states():
+            return ("active", progress)
+        elif state in TorrentState.error_states():
+            return ("error", progress)
+        elif state in TorrentState.stopped_states():
+            return ("stopped", progress)
+        else:
+            return (state, progress)
+    
+    # ==================== CLEANUP ====================
+    
+    def end_session(self):
+        """Logout from the qBittorrent client."""
+        return self.api_client.auth_log_out()
+    
+    def shutdown(self, wait: bool = True):
+        """
+        Shutdown the client and background executor.
+        
+        Args:
+            wait: If True, wait for background tasks to complete.
+        """
+        # Cancel all active tasks
+        with self._tasks_lock:
+            for event in self._active_tasks.values():
+                event.set()
+        
+        # Shutdown executor
+        self._executor.shutdown(wait=wait)
+        
+        # Logout
+        try:
+            self.api_client.auth_log_out()
+        except Exception:
+            pass

--- a/toloka2MediaServer/clients/qbittorrent.py
+++ b/toloka2MediaServer/clients/qbittorrent.py
@@ -88,10 +88,14 @@ class QbittorrentClient(BittorrentClient):
                 torrent_hash = torrents[0].hash
                 # Remove temporary tag
                 try:
+                    # First remove tag from this torrent
                     self.api_client.torrents_remove_tags(
                         tags=temp_tag,
                         torrent_hashes=torrent_hash
                     )
+                    
+                    # Delete the temporary tag completely
+                    self.api_client.torrents_delete_tags(tags=temp_tag)
                 except:
                     # If removing temp tag fails, it's not critical
                     pass

--- a/toloka2MediaServer/clients/qbittorrent.py
+++ b/toloka2MediaServer/clients/qbittorrent.py
@@ -1,4 +1,5 @@
 import qbittorrentapi
+import time
 
 from toloka2MediaServer.clients.bittorrent_client import BittorrentClient
 
@@ -59,27 +60,223 @@ class QbittorrentClient(BittorrentClient):
     def get_files(self, torrent_hash):
         return self.api_client.torrents_files(torrent_hash)
 
+    def _retry_operation(self, operation_func, verification_func, operation_name, max_retries=3, retry_delay=2, initial_wait=1):
+        """Helper method to handle retry logic for torrent operations.
+        
+        Args:
+            operation_func: Function that performs the operation
+            verification_func: Function that verifies if operation was successful
+            operation_name (str): Name of operation for error messages
+            max_retries (int): Maximum number of retry attempts
+            retry_delay (int): Delay between retries in seconds
+            initial_wait (int): Initial wait time after operation before first verification
+            
+        Returns:
+            bool: True if operation was successful, False otherwise
+            
+        Raises:
+            Exception: If operation fails after all retries
+        """
+        for attempt in range(max_retries):
+            try:
+                operation_func()
+                # Always wait a bit after the operation before checking
+                time.sleep(initial_wait)
+                
+                if verification_func():
+                    return True
+                    
+                if attempt < max_retries - 1:
+                    time.sleep(retry_delay)
+                    continue
+                    
+                return False
+                
+            except Exception as e:
+                if attempt < max_retries - 1:
+                    time.sleep(retry_delay)
+                    continue
+                raise Exception(f"Failed to {operation_name} after {max_retries} attempts: {str(e)}")
+                
+        return False
+
     def rename_file(self, torrent_hash, old_path, new_path):
-        return self.api_client.torrents_rename_file(
-            torrent_hash=torrent_hash, old_path=old_path, new_path=new_path
+        """Rename a file in a torrent with retries and verification.
+        
+        Args:
+            torrent_hash (str): Hash of the torrent
+            old_path (str): Current file path
+            new_path (str): New file path
+            
+        Returns:
+            bool: True if rename was successful
+        """
+        def operation():
+            self.api_client.torrents_rename_file(
+                torrent_hash=torrent_hash,
+                old_path=old_path,
+                new_path=new_path
+            )
+            
+        def verify():
+            files = self.get_files(torrent_hash)
+            # Check both that new path exists and old path doesn't
+            new_path_exists = any(file.name == new_path for file in files)
+            old_path_exists = any(file.name == old_path for file in files)
+            return new_path_exists and not old_path_exists
+            
+        return self._retry_operation(
+            operation,
+            verify,
+            "rename file",
+            max_retries=3,
+            retry_delay=2,
+            initial_wait=1
         )
 
     def rename_folder(self, torrent_hash, old_path, new_path):
-        return self.api_client.torrents_rename_folder(
-            torrent_hash=torrent_hash, old_path=old_path, new_path=new_path
+        """Rename a folder in a torrent with retries and verification.
+        
+        Args:
+            torrent_hash (str): Hash of the torrent
+            old_path (str): Current folder path
+            new_path (str): New folder path
+            
+        Returns:
+            bool: True if rename was successful
+        """
+        def operation():
+            self.api_client.torrents_rename_folder(
+                torrent_hash=torrent_hash,
+                old_path=old_path,
+                new_path=new_path
+            )
+            
+        def verify():
+            files = self.get_files(torrent_hash)
+            # Check that no files contain the old path and at least one contains the new path
+            old_path_exists = any(old_path in file.name for file in files)
+            new_path_exists = any(new_path in file.name for file in files)
+            return new_path_exists and not old_path_exists
+            
+        return self._retry_operation(
+            operation,
+            verify,
+            "rename folder",
+            max_retries=3,
+            retry_delay=2,
+            initial_wait=1
         )
 
     def rename_torrent(self, torrent_hash, new_torrent_name):
-        return self.api_client.torrents_rename(
-            torrent_hash=torrent_hash, new_torrent_name=new_torrent_name
+        """Rename a torrent with retries and verification.
+        
+        Args:
+            torrent_hash (str): Hash of the torrent
+            new_torrent_name (str): New name for the torrent
+            
+        Returns:
+            bool: True if rename was successful
+        """
+        def operation():
+            self.api_client.torrents_rename(
+                torrent_hash=torrent_hash,
+                new_torrent_name=new_torrent_name
+            )
+            
+        def verify():
+            torrent_info = self.get_torrent_info(
+                status_filter=None,
+                category=None,
+                tags=None,
+                sort=None,
+                reverse=False,
+                torrent_hash=torrent_hash
+            )
+            # Verify both that torrent exists and has the new name
+            return torrent_info and len(torrent_info) > 0 and torrent_info[0].name == new_torrent_name
+            
+        return self._retry_operation(
+            operation,
+            verify,
+            "rename torrent",
+            max_retries=3,
+            retry_delay=2,
+            initial_wait=1
         )
 
     def resume_torrent(self, torrent_hashes):
-        return self.api_client.torrents_resume(torrent_hashes=torrent_hashes)
+        """Resume torrent with verification.
+        
+        Args:
+            torrent_hashes (str): Hash of the torrent
+            
+        Returns:
+            bool: True if resume was successful
+        """
+        def operation():
+            self.api_client.torrents_resume(torrent_hashes=torrent_hashes)
+            
+        def verify():
+            torrent_info = self.get_torrent_info(
+                status_filter=None,
+                category=None,
+                tags=None,
+                sort=None,
+                reverse=False,
+                torrent_hash=torrent_hashes
+            )
+            if not torrent_info:
+                return False
+                
+            state = torrent_info[0].state
+            # States indicating torrent is active or queued
+            valid_states = [
+                'downloading', 'uploading',
+                'stalledDL', 'stalledUP',
+                'forcedDL', 'forcedUP',
+                'metaDL', 'allocating',
+                'checkingDL', 'checkingUP',
+                'queuedDL', 'queuedUP'  # Include queued states as valid
+            ]
+            return state in valid_states
+            
+        return self._retry_operation(
+            operation,
+            verify,
+            "resume torrent",
+            max_retries=3,
+            retry_delay=5,
+            initial_wait=1
+        )
 
     def delete_torrent(self, delete_files, torrent_hashes):
-        return self.api_client.torrents_delete(
-            delete_files=delete_files, torrent_hashes=torrent_hashes
+        """Delete torrent with verification."""
+        def operation():
+            self.api_client.torrents_delete(
+                delete_files=delete_files,
+                torrent_hashes=torrent_hashes
+            )
+            
+        def verify():
+            # Verify torrent no longer exists
+            torrent_info = self.get_torrent_info(
+                status_filter=None,
+                category=None,
+                tags=None,
+                sort=None,
+                reverse=False,
+                torrent_hash=torrent_hashes
+            )
+            return not torrent_info
+            
+        return self._retry_operation(
+            operation,
+            verify,
+            "delete torrent",
+            max_retries=3,
+            retry_delay=2,
+            initial_wait=1
         )
 
     def recheck_torrent(self, torrent_hashes):
@@ -87,3 +284,134 @@ class QbittorrentClient(BittorrentClient):
 
     def end_session(self):
         return self.api_client.auth_log_out()
+
+    def recheck_and_resume(self, torrent_hash):
+        """Recheck and resume torrent with verification.
+        
+        Args:
+            torrent_hash (str): Hash of the torrent
+            
+        Returns:
+            bool: True if operation was successful
+        """
+        def recheck_operation():
+            self.api_client.torrents_recheck(torrent_hashes=torrent_hash)
+            
+        def verify_recheck():
+            torrent_info = self.get_torrent_info(
+                status_filter=None,
+                category=None,
+                tags=None,
+                sort=None,
+                reverse=False,
+                torrent_hash=torrent_hash
+            )
+            if not torrent_info:
+                return False
+                
+            state = torrent_info[0].state
+            
+            # States indicating recheck/verification is in progress
+            checking_states = [
+                'checkingResumeData',  # Initial check on startup
+                'checking',            # Generic checking
+                'checkingDL',          # Checking incomplete torrent
+                'checkingUP'           # Checking completed torrent
+            ]
+            
+            # States indicating torrent is in a valid state after check
+            valid_states = [
+                # Active states
+                'downloading', 'uploading',
+                'stalledDL', 'stalledUP',
+                'forcedDL', 'forcedUP',
+                'metaDL',
+                # Queued states
+                'queuedDL', 'queuedUP',
+                # Paused states
+                'pausedDL', 'pausedUP',
+                # Special states
+                'allocating'
+            ]
+            
+            # Still checking
+            if state in checking_states:
+                return False
+                
+            # Valid state reached
+            if state in valid_states:
+                return True
+                
+            # Special cases
+            if state == 'moving':
+                return False  # Wait for move to complete
+                
+            # Error states
+            if state in ['error', 'missingFiles', 'unknown']:
+                return False
+                
+            return False
+        
+        recheck_success = self._retry_operation(
+            recheck_operation,
+            verify_recheck,
+            "recheck torrent",
+            max_retries=5,
+            retry_delay=15,
+            initial_wait=2  # Longer initial wait for recheck
+        )
+        
+        # Even if recheck "failed", try to resume if torrent exists
+        torrent_info = self.get_torrent_info(
+            status_filter=None,
+            category=None,
+            tags=None,
+            sort=None,
+            reverse=False,
+            torrent_hash=torrent_hash
+        )
+        
+        if not torrent_info:
+            return False
+            
+        def resume_operation():
+            self.api_client.torrents_resume(torrent_hashes=torrent_hash)
+            
+        def verify_resume():
+            torrent_info = self.get_torrent_info(
+                status_filter=None,
+                category=None,
+                tags=None,
+                sort=None,
+                reverse=False,
+                torrent_hash=torrent_hash
+            )
+            if not torrent_info:
+                return False
+                
+            state = torrent_info[0].state
+            
+            # States indicating active operation
+            active_states = [
+                # Active transfer states
+                'downloading', 'uploading',
+                'stalledDL', 'stalledUP',
+                'forcedDL', 'forcedUP',
+                'metaDL',
+                # Verification states (acceptable since they're part of normal operation)
+                'checkingDL', 'checkingUP',
+                # Special states
+                'allocating'
+            ]
+            return state in active_states
+            
+        resume_success = self._retry_operation(
+            resume_operation,
+            verify_resume,
+            "resume torrent",
+            max_retries=3,
+            retry_delay=5,
+            initial_wait=1
+        )
+        
+        return resume_success

--- a/toloka2MediaServer/clients/qbittorrent.py
+++ b/toloka2MediaServer/clients/qbittorrent.py
@@ -211,9 +211,9 @@ class QbittorrentClient(BittorrentClient):
             operation,
             verify,
             "rename file",
-            max_retries=3,
-            retry_delay=2,
-            initial_wait=1
+            max_retries=10,
+            retry_delay=3,
+            initial_wait=3
         )
 
     def rename_folder(self, torrent_hash, old_path, new_path):
@@ -245,9 +245,9 @@ class QbittorrentClient(BittorrentClient):
             operation,
             verify,
             "rename folder",
-            max_retries=3,
-            retry_delay=2,
-            initial_wait=1
+            max_retries=10,
+            retry_delay=3,
+            initial_wait=3
         )
 
     def rename_torrent(self, torrent_hash, new_torrent_name):
@@ -284,9 +284,9 @@ class QbittorrentClient(BittorrentClient):
             operation,
             verify,
             "rename torrent",
-            max_retries=3,
-            retry_delay=2,
-            initial_wait=1
+            max_retries=10,
+            retry_delay=3,
+            initial_wait=3
         )
 
     def resume_torrent(self, torrent_hashes):
@@ -329,9 +329,9 @@ class QbittorrentClient(BittorrentClient):
             operation,
             verify,
             "resume torrent",
-            max_retries=3,
+            max_retries=10,
             retry_delay=5,
-            initial_wait=1
+            initial_wait=3
         )
 
     def delete_torrent(self, delete_files, torrent_hashes):
@@ -405,7 +405,7 @@ class QbittorrentClient(BittorrentClient):
         try:
             # Add overall timeout
             overall_start_time = time.time()
-            overall_timeout = 300  # 5 minutes total timeout
+            overall_timeout = 360
             
             def check_overall_timeout():
                 if time.time() - overall_start_time > overall_timeout:
@@ -432,7 +432,7 @@ class QbittorrentClient(BittorrentClient):
                 pass
             
             # Wait for recheck to start (with retry)
-            check_interval = 3
+            check_interval = 10
             max_retries = 10
             recheck_started = False
             

--- a/toloka2MediaServer/main_logic.py
+++ b/toloka2MediaServer/main_logic.py
@@ -43,6 +43,11 @@ def add_release_by_url(config):
     else:
         title.code_name = base_code_name
 
+    # Set partial season flag if provided
+    title.is_partial_season = bool(getattr(config.args, 'partial', False))
+    if title.is_partial_season:
+        config.logger.info(f"Processing as partial season release for {title.code_name}")
+
     # Collect additional data
     title.season_number = season_number.zfill(2)
     default_download_dir = config.application_config.default_download_dir

--- a/toloka2MediaServer/main_logic.py
+++ b/toloka2MediaServer/main_logic.py
@@ -54,8 +54,10 @@ def add_release_by_url(config):
     title.release_group = torrent.author
     default_meta = config.application_config.default_meta
     title.meta = default_meta
-    config.operation_result = add(config, title, torrent)
-
+    result = add(config, title, torrent)
+    
+    # Preserve the response code from the add operation
+    config.operation_result.response_code = result.response_code
     return config.operation_result
 
 

--- a/toloka2MediaServer/main_logic.py
+++ b/toloka2MediaServer/main_logic.py
@@ -56,9 +56,10 @@ def add_release_by_url(config):
     else:
         title.download_dir = default_download_dir
     title.torrent_name = config.args.title.strip() or suggested_name.strip()
-    title.release_group = torrent.author
+    # Use args when provided, otherwise library defaults (torrent.author / default_meta)
+    title.release_group = getattr(config.args, "release_group", None) or torrent.author
     default_meta = config.application_config.default_meta
-    title.meta = default_meta
+    title.meta = getattr(config.args, "meta", None) or default_meta
     result = add(config, title, torrent)
     
     # Preserve the response code from the add operation

--- a/toloka2MediaServer/models/application.py
+++ b/toloka2MediaServer/models/application.py
@@ -12,7 +12,6 @@ class Application:
     wait_time: int = 0
     client_wait_time: int = 0
     enable_dot_spacing_in_file_name: bool = True
-    sonarr_support: bool = False
 
 
 def app_to_config(app):

--- a/toloka2MediaServer/models/application.py
+++ b/toloka2MediaServer/models/application.py
@@ -12,6 +12,7 @@ class Application:
     wait_time: int = 0
     client_wait_time: int = 0
     enable_dot_spacing_in_file_name: bool = True
+    sonarr_support: bool = False
 
 
 def app_to_config(app):

--- a/toloka2MediaServer/models/title.py
+++ b/toloka2MediaServer/models/title.py
@@ -15,6 +15,7 @@ class Title:
     hash: str = ""
     adjusted_episode_number: int = 0
     guid: str = ""
+    is_partial_season: bool = False
 
 
 def title_to_config(title):
@@ -39,6 +40,7 @@ def title_to_config(title):
         "hash": title.hash,
         "adjusted_episode_number": str(title.adjusted_episode_number),
         "guid": title.guid,
+        "is_partial_season": str(title.is_partial_season),
     }
 
     return config
@@ -71,4 +73,5 @@ def config_to_title(config, code_name):
         hash=section.get("hash", ""),
         adjusted_episode_number=int(section.get("adjusted_episode_number", 0)),
         guid=section.get("guid", ""),
+        is_partial_season=section.get("is_partial_season", "False").lower() == "true",
     )

--- a/toloka2MediaServer/utils/operation_decorator.py
+++ b/toloka2MediaServer/utils/operation_decorator.py
@@ -21,13 +21,13 @@ def operation_tracker(operation_type):
             # Set operation details
             config.operation_result.operation_type = operation_type
             config.operation_result.start_time = datetime.now()
-            config.operation_result.response_code = (
-                ResponseCode.PARTIAL
-            )  # Assume partial unless completed
+            config.operation_result.response_code = ResponseCode.PARTIAL  # Initial state
 
             try:
-                config.operation_result = func(*args, **kwargs)
-                config.operation_result.response_code = ResponseCode.SUCCESS
+                result = func(*args, **kwargs)
+                # Don't override the response_code if it was set to FAILURE by the function
+                if config.operation_result.response_code == ResponseCode.PARTIAL:
+                    config.operation_result.response_code = ResponseCode.SUCCESS
             except Exception as e:
                 config.operation_result.response_code = ResponseCode.FAILURE
                 if not hasattr(config.operation_result, "operation_logs"):

--- a/toloka2MediaServer/utils/torrent_processor.py
+++ b/toloka2MediaServer/utils/torrent_processor.py
@@ -162,7 +162,10 @@ def process_torrent(config, title, torrent, new=False):
         if new:
             success = config.client.resume_torrent(torrent_hashes=title.hash)
         else:
-            success = config.client.recheck_and_resume(torrent_hash=title.hash)
+            success, message = config.client.recheck_and_resume(torrent_hash=title.hash)
+            if message:
+                config.operation_result.operation_logs.append(message)
+                config.logger.warning(message)
             
         if not success:
             message = f"Failed to start torrent: {torrent.name}"


### PR DESCRIPTION
Partial season support (ongoing shows)
You can mark a release as a partial season (e.g. with --partial or the equivalent option in the web client).
Folder names now include the episode range (e.g. “Show S01E01–E03” instead of “Show S01”), so it’s clear how many episodes are in the pack.
When you update with new episodes, existing files are kept and only new ones are downloaded, so recheck works and you save bandwidth.
qBittorrent improvements
Recheck after updates runs in the background so the UI doesn’t hang.
More reliable handling of recheck, resume, and file/folder renames.